### PR TITLE
Update Yubikey Manager to 5.2.0

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : yubikey-manager
-version    : 5.1.1
-release    : 37
+version    : 5.2.0
+release    : 38
 source     :
-    - https://github.com/Yubico/yubikey-manager/releases/download/5.1.1/yubikey_manager-5.1.1.tar.gz : 6487db976d8b5b52965db55d084f9d2aef2b96f77da785dc13f6dfdd3302aace
+    - https://github.com/Yubico/yubikey-manager/releases/download/5.2.0/yubikey_manager-5.2.0.tar.gz : 45e0f09e3cee2375b6f930dd5d89c1d3a7ca5d5cccb599b16a12f8f7d989fd36
 license    : BSD-2-Clause
 component  : security
 summary    : Command line utility for configuring your YubiKey

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>yubikey-manager</Name>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>tracey_dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -31,6 +31,8 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/diagnostics.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/fido.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/fido.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/hsmauth.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/hsmauth.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/logging.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/logging.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/__pycache__/logging_setup.cpython-310.opt-1.pyc</Path>
@@ -63,6 +65,8 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/config.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/fido.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/fido.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/hsmauth.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/hsmauth.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/info.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/info.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/__pycache__/oath.cpython-310.opt-1.pyc</Path>
@@ -81,6 +85,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/apdu.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/config.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/fido.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/hsmauth.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/info.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/oath.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/_cli/openpgp.py</Path>
@@ -110,6 +115,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/hid/linux.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/hid/macos.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/hid/windows.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/hsmauth.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/logging.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/logging_setup.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/oath.py</Path>
@@ -150,14 +156,16 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/scripting.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/ykman/util.py</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.1.1.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.1.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.1.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.1.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.1.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.2.0.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.2.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.2.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.2.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikey_manager-5.2.0.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/hsmauth.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/hsmauth.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/logging.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/logging.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/__pycache__/management.cpython-310.opt-1.pyc</Path>
@@ -184,6 +192,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/core/fido.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/core/otp.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/core/smartcard.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/hsmauth.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/logging.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/management.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/yubikit/oath.py</Path>
@@ -196,12 +205,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2023-07-09</Date>
-            <Version>5.1.1</Version>
+        <Update release="38">
+            <Date>2023-09-02</Date>
+            <Version>5.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>tracey_dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

- PIV: Support for compressed certificates.
- OpenPGP: Use InvalidPinError for wrong PIN.
- Add YubiHSM Auth application support.
- Improved API documentation.
- Scripting: Add name attribute to device.
- Bugfix: PIV: don't throw InvalidPasswordError on malformed PEM private key.

Full release notes available [here](https://github.com/Yubico/yubikey-manager/releases)

### Test Plan

- YubiKey Manager can be run with `ykman`
- Program behaves as expected

### Checklist

- [ x] Package was built and tested against unstable
